### PR TITLE
v1.0.1 - Resolve ESP32 v2.0.5 warnings-as-errors

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SparkFun Qwiic TMF882X Library
-version=1.0.0
+version=1.0.1
 author=SparkFun Electronics <techsupport@sparkfun.com>
 maintainer=SparkFun Electronics <sparkfun.com>
 sentence=Library for the SparkFun Qwiic breakout boards for the AMS TMF882X sensor products.

--- a/src/qwiic_tmf882x.cpp
+++ b/src/qwiic_tmf882x.cpp
@@ -195,7 +195,7 @@ bool QwDevTMF882X::setI2CAddress(uint8_t address)
 {
     // Initialized? Is the address legal?
     if (!_isInitialized || address < 0x08 || address > 0x77)
-        false;
+        return false;
 
     // is the address the same as already set?
     if (address == _i2cAddress)

--- a/src/qwiic_tmf882x.h
+++ b/src/qwiic_tmf882x.h
@@ -679,12 +679,23 @@ class QwDevTMF882X
     // Library initialized flag
     bool _isInitialized;
 
+    // Delay for the read sample loop
+    uint16_t _sampleDelayMS;
+
+    // for managing message output levels
+    uint8_t _outputSettings;
+    bool _debug;
+
+    // Callback function pointers
+    TMF882XMeasurementHandler _measurementHandlerCB;
+    TMF882XHistogramHandler _histogramHandlerCB;
+    TMF882XStatsHandler _statsHandlerCB;
+    TMF882XErrorHandler _errorHandlerCB;
+    TMF882XMessageHandler _messageHandlerCB;
+
     // I2C  things
     QwI2C *_i2cBus;      // pointer to our i2c bus object
     uint8_t _i2cAddress; // address of the device
-
-    // Delay for the read sample loop
-    uint16_t _sampleDelayMS;
 
     // Structure/state for the underlying TOF SDK
     tmf882x_tof _TOF;
@@ -698,16 +709,4 @@ class QwDevTMF882X
     // Flag to indicate to the system to stop measurements
     bool _stopMeasuring;
 
-    // Callbacks
-    //
-    // Callback function pointers
-    TMF882XMeasurementHandler _measurementHandlerCB;
-    TMF882XHistogramHandler _histogramHandlerCB;
-    TMF882XStatsHandler _statsHandlerCB;
-    TMF882XErrorHandler _errorHandlerCB;
-    TMF882XMessageHandler _messageHandlerCB;
-
-    // for managing message output levels
-    uint8_t _outputSettings;
-    bool _debug;
 };

--- a/src/tmf882x_interface.c
+++ b/src/tmf882x_interface.c
@@ -96,8 +96,7 @@ int32_t tmf882x_open(struct tmf882x_tof * tof)
 
     if (tof->state.ops->open &&
         tof->state.ops->open(&tof->state)) {
-        tof_err(to_priv(&tof->state), "Error opening mode: %#x",
-                mode);
+        tof_err(to_priv(&tof->state), "Error opening mode");
         tmf882x_init(tof, to_priv(&tof->state));
         return -1;
     }

--- a/src/tmf882x_mode_app.c
+++ b/src/tmf882x_mode_app.c
@@ -417,7 +417,7 @@ static uint8_t get_app_cmd_stat(struct tmf882x_mode_app *app)
 }
 
 static int32_t check_cmd_status(struct tmf882x_mode_app *app,
-                            uint32_t retries)
+                            int32_t retries)
 {
     int32_t num_retries;
     uint8_t status;

--- a/src/tmf882x_mode_bl.c
+++ b/src/tmf882x_mode_bl.c
@@ -128,7 +128,7 @@ int32_t tmf882x_mode_bl_read_status(struct tmf882x_mode_bl *bl,
             continue;
         }
         /* if we have reached here, the command has either succeeded or failed */
-        if ( *rdata_size >= 0 ) {
+        if ( *rdata_size > 0 ) {
             /* read in data part and csum */
             error = tof_i2c_read(priv(bl), BL_REG_CMD_STATUS,
                     rbuf, BL_CALC_RSP_SIZE(*rdata_size));


### PR DESCRIPTION
Resolves warnings-as-errors.... But PLEASE CHECK these two commits: df7dd8621fd42a8e2f9190f0e8101406a8e4f646 and cd7abd2cc5f675817f4d1e9f98328dc5e92f3480 . Thanks!
